### PR TITLE
Fixed strict mode warning for DefaultArray::fromArray

### DIFF
--- a/nspl/ds/DefaultArray.php
+++ b/nspl/ds/DefaultArray.php
@@ -22,12 +22,14 @@ class DefaultArray extends ArrayObject
     }
 
     /**
+     * Create an instance of default array using `null` for the default value.
+     *
      * @param array $array
      * @return static
      */
-    public static function fromArray($default, array $array)
+    public static function fromArray(array $array)
     {
-        $result = new static($default);
+        $result = new static(null);
         $result->array = $array;
 
         return $result;
@@ -64,7 +66,7 @@ class DefaultArray extends ArrayObject
             $this->offsetSet($index, $this->getDefault());
         }
 
-        return parent::offsetGet($index);
+        return $this->array[$index];
     }
     //endregion
 }

--- a/nspl/ds/DefaultArray.php
+++ b/nspl/ds/DefaultArray.php
@@ -57,7 +57,6 @@ class DefaultArray extends ArrayObject
      * @param int $index <p>
      * The offset to retrieve.
      * </p>
-     * @throws \Exception
      * @return mixed Can return all value types.
      */
     public function &offsetGet($index)

--- a/tests/NsplTest/DSTest.php
+++ b/tests/NsplTest/DSTest.php
@@ -90,6 +90,11 @@ class DsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $array['oranges']);
         $this->assertEquals(20, $array['apples']);
         $this->assertEquals(30, $array['bananas']);
+
+        $array = DefaultArray::fromArray(array('apples' => 20, 'bananas' => 30));
+        $this->assertEquals(20, $array['apples']);
+        $this->assertEquals(30, $array['bananas']);
+        $this->assertNull($array['invalid']);
     }
 
     public function testSet()


### PR DESCRIPTION
Fixes issue #1 

So while looking at the source, there was no way to patch `DefaultArray::fromArray` as it will always break inheritance here. The approach I took was to remove the additional `$default` parameter from `fromArray` and let the default in this instance to be `null`. This required me to update `&offsetGet` to get it to return a `null` value.

This approach will break applications using it in the wild as it does change the method signature for `fromArray`, but without implementing `$default` on everything, there seems very little other option.

I have included unit tests for this specified functionality.
