### PR TITLE
[Bugfix] Ensure that array cannot be null to call array_values(array)

### DIFF
--- a/nspl/ds/Set.php
+++ b/nspl/ds/Set.php
@@ -8,6 +8,7 @@ class Set extends Collection
 {
     public function __construct(/* $e1, $e2, ..., $eN */)
     {
+        $this->array = array();
         foreach (func_get_args() as $element) {
             $this->array[static::getElementKey($element)] = $element;
         }

--- a/tests/NsplTest/DSTest.php
+++ b/tests/NsplTest/DSTest.php
@@ -162,6 +162,9 @@ class DsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($set->contains(1));
         $this->assertTrue($set->contains(2));
         $this->assertTrue($set->contains(3));
+        
+        $set = set();
+        $this->assertEquals($set->toArray(), array());
     }
 
     //region deprecated


### PR DESCRIPTION
The array-values() function needs an array in input and can't have a null value. (from the hint)
I wrote a test to illustrate this problem.
