### PR TITLE
[hotfix] remove php56 breaking syntax

### DIFF
--- a/nspl/op.php
+++ b/nspl/op.php
@@ -178,12 +178,6 @@ function instanceCreator($class)
 {
     args\expects(args\string, $class);
 
-    if (version_compare(PHP_VERSION, '5.6', '>=')) {
-        return function(...$args) use ($class) {
-            return new $class(...$args);
-        };
-    }
-
     $reflectionClass = new \ReflectionClass($class);
 
     return function() use ($class, $reflectionClass) {


### PR DESCRIPTION
In the last release (1.2.1) we introduced a syntax error for PHP < 5.6